### PR TITLE
Fix linter errors

### DIFF
--- a/modules/10-basics/10-hello-world/index.rb
+++ b/modules/10-basics/10-hello-world/index.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+# BEGIN
+
 def print_hello
   puts 'Hello, World!'
 end
@@ -5,3 +9,5 @@ end
 print_hello
 print_hello
 print_hello
+
+# END

--- a/modules/10-basics/20-arithmetics/index.rb
+++ b/modules/10-basics/20-arithmetics/index.rb
@@ -2,8 +2,8 @@
 
 # BEGIN
 
-def sum_of_squares(a, b, c)
-  puts a**2 + b**2 + c**2
+def sum_of_squares(first, second, third)
+  puts first**2 + second**2 + third**2
 end
 
 sum_of_squares(3, 4, 5)

--- a/modules/10-basics/20-arithmetics/index.rb
+++ b/modules/10-basics/20-arithmetics/index.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+# BEGIN
+
 def sum_of_squares(a, b, c)
   puts a**2 + b**2 + c**2
 end
@@ -5,3 +9,5 @@ end
 sum_of_squares(3, 4, 5)
 sum_of_squares(0, 2, 3)
 sum_of_squares(-5, 10, 4)
+
+# END

--- a/modules/10-basics/30-returns/index.rb
+++ b/modules/10-basics/30-returns/index.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# BEGIN
+
 def total_salary(logged_hours, salary, exchange_rate)
   logged_hours * salary * exchange_rate
 end
+
+# END

--- a/modules/10-basics/40-logic/index.rb
+++ b/modules/10-basics/40-logic/index.rb
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
+# BEGIN
+
 def can_take_order?(works_today, occupied_today, force_assignment)
   works_today && !occupied_today || force_assignment
 end
+
+# END

--- a/modules/10-basics/50-conditions/index.rb
+++ b/modules/10-basics/50-conditions/index.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/NumericPredicate
+
 # BEGIN
 
 def leap?(year)
@@ -13,3 +15,5 @@ def leap?(year)
 end
 
 # END
+
+# rubocop:enable Style/NumericPredicate

--- a/modules/10-basics/50-conditions/index.rb
+++ b/modules/10-basics/50-conditions/index.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# BEGIN
 
 def leap?(year)
   if year % 400 == 0
@@ -8,3 +11,5 @@ def leap?(year)
     year % 4 == 0
   end
 end
+
+# END

--- a/modules/10-basics/50-conditions/test.rb
+++ b/modules/10-basics/50-conditions/test.rb
@@ -3,12 +3,12 @@
 require 'code_basics'
 
 CodeBasics.execute!(__dir__) do |_stdout, result|
-    assert { result.leap?(1600) == true }
-    assert { result.leap?(1601) == false }
-    assert { result.leap?(1602) == false }
-    assert { result.leap?(1603) == false }
-    assert { result.leap?(1604) == true }
-    assert { result.leap?(1800) == false }
-    assert { result.leap?(1900) == false }
-    assert { result.leap?(2000) == true }
+  assert { result.leap?(1600) == true }
+  assert { result.leap?(1601) == false }
+  assert { result.leap?(1602) == false }
+  assert { result.leap?(1603) == false }
+  assert { result.leap?(1604) == true }
+  assert { result.leap?(1800) == false }
+  assert { result.leap?(1900) == false }
+  assert { result.leap?(2000) == true }
 end


### PR DESCRIPTION
1. Добавил магические комменты для заморозки строк
2. Вместе с этим, добавил комменты BEGIN/END
3. Переименовал аргументы в sum_of_squares — они были слишком
короткими.
4. Отключил проверку, которая требовала заменить `== 0` на `zero?`. Для
образовательных целей лучше её оставить