### PR TITLE
update teacher solution

### DIFF
--- a/modules/25-functions/10-functions-definition-splat/index.rb
+++ b/modules/25-functions/10-functions-definition-splat/index.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 # BEGIN
-def merge_all(*hashes)
-  result = {}
-  hashes.each do |hash|
-    result = result.merge(hash)
-  end
-  result
+def merge_all(first_hash, *rest_hashes)
+  first_hash.merge(*rest_hashes)
 end
 # END


### PR DESCRIPTION
Кажется, что решение с разбиением первого и `*rest` хешей хорошо подчеркивает описание урока и в общем-то оттуда просто выводится, т.к. есть пример с `(number, *numbers)`. Да и выглядит более ruby way имхо.