### PR TITLE
fix annotation code to be valid

### DIFF
--- a/modules/25-functions/50-functions-symbols-to-blocks/description.ru.yml
+++ b/modules/25-functions/50-functions-symbols-to-blocks/description.ru.yml
@@ -16,7 +16,7 @@ theory: |
 
   ```ruby
   block = :capitalize.to_proc
-  # proc = { |value| value.capitalize }
+  # block = proc { |value| value.capitalize }
   block.call('hexlet') # "Hexlet"
   ```
 


### PR DESCRIPTION
Annotation code `proc = { |value| value.capitalize }` doesn't work as written. Fixing it as seems it was intended.