### PR TITLE
Fix 10-each-with-object

### DIFF
--- a/modules/40-arrays/10-each-with-object/description.ru.yml
+++ b/modules/40-arrays/10-each-with-object/description.ru.yml
@@ -38,9 +38,9 @@ instructions: |
   # {
   #   b: ['become'],
   #   d: ['developers'],
-  #   t: ['to'],
-  #   h: ['hexlet', 'helps'],
-  #   p: ['people']
+  #   h: ['helps', 'hexlet'],
+  #   p: ['people'],
+  #   t: ['to']
   # }
   ```
 

--- a/modules/40-arrays/10-each-with-object/index.rb
+++ b/modules/40-arrays/10-each-with-object/index.rb
@@ -2,7 +2,7 @@
 
 # BEGIN
 def words_by_letters(sentence)
-  words = sentence.split
+  words = sentence.split.sort
   words.each_with_object({}) do |word, acc|
     acc[word[0]] ||= []
     acc[word[0]] << word

--- a/modules/40-arrays/10-each-with-object/test.rb
+++ b/modules/40-arrays/10-each-with-object/test.rb
@@ -10,10 +10,11 @@ describe 'function' do
     expected = {
       'b' => ['become'],
       'd' => ['developers'],
-      't' => ['to'],
-      'h' => %w[hexlet helps],
-      'p' => ['people']
+      'h' => %w[helps hexlet],
+      'p' => ['people'],
+      't' => ['to']
     }
     assert { actual == expected }
+    assert { actual.keys == expected.keys }
   end
 end


### PR DESCRIPTION
В тестах были ошибки. Предполагается, что буквы должны быть по алфавиту, 
но при этом буква 't' находились раньше, чем буквы 'h' и 'p'. Также в 
тестах этот момент не проверялся, поскольку руби сравнивает значения, а 
не ссылки, поэтому тесты проходили. Если добавить сравнения для ключей, 
то мы увидим, что ошибка имеется, поэтому там тоже внёс изменения.