### PR TITLE
Upgrade Ruby to 4.0 via multi-stage build

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,9 +4,9 @@ AllCops:
   Include:
     - 'lib/**/*.rb'
     - 'modules/**/*.rb'
-  TargetRubyVersion: 3.3.0
+  TargetRubyVersion: 4.0
 
-require:
+plugins:
   - rubocop-minitest
 
 Style/FrozenStringLiteralComment:
@@ -24,6 +24,9 @@ Metrics/MethodLength:
   Enabled: false
 
 Style/EachWithObject:
+  Enabled: false
+
+Style/ReduceToHash:
   Enabled: false
 
 Style/AsciiComments:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
+FROM ruby:4.0-slim-bookworm AS ruby-source
 FROM hexletbasics/base-image:latest
+
+COPY --from=ruby-source /usr/local /usr/local
 
 ENV RUBYLIB=/exercises-ruby/lib
 ENV PATH=/exercises-ruby/bin:$PATH
 
-RUN apt-get update && \
-    apt-get install -y ruby-full bundler && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN gem install bundler
 
 WORKDIR /exercises-ruby
 


### PR DESCRIPTION
## Summary

- PR #170 (dependabot gem bumps) caused CI to fail: new gems require Ruby ≥ 3.2, but the Dockerfile installed `ruby-full` via APT (Ruby 3.1 on Debian Bookworm / `node:25-slim`).
- During Docker build, bundler was silently downgrading `activesupport 8.1.3 → 7.0.10` to satisfy Ruby 3.1, then `COPY . .` overwrote `Gemfile.lock` back to 8.1.3 — causing `Bundler::GemNotFound` at runtime.

**Fix:**
- Replace APT `ruby-full` with a multi-stage build from `ruby:4.0-slim-bookworm` (Bookworm variant ensures GLIBC compatibility with `hexletbasics/base-image`)
- Update `.rubocop.yml`: `plugins:` instead of deprecated `require:`, `TargetRubyVersion 4.0`, disable `Style/ReduceToHash` (exercises intentionally use `each_with_object`)

## Test plan

- [x] `docker build` completes successfully (all 41 gems installed, including activesupport 8.1.3, minitest 6.0.6)
- [x] `make code-lint` — rubocop: 64 files, no offenses
- [x] `make test` — all tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)